### PR TITLE
Use Alpine latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:latest
 ENV AWSCLI_VERSION "1.16.310"
 RUN apk -v --no-cache --update add \
         python \


### PR DESCRIPTION
First, thanks for the awesome automation on this.

Currently it's `3.6`. Is there a reason not to use latest Alpine?