### PR TITLE
Disable apk and pip cache when installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine:3.6
-
 ENV AWSCLI_VERSION "1.16.309"
 RUN apk -v --no-cache --update add \
         python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:3.6
 ENV AWSCLI_VERSION "1.16.19"
-RUN apk -v --update add \
+RUN apk -v --no-cache --update add \
         python \
         py-pip \
         groff \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==${AWSCLI_VERSION} && \
+    pip --no-cache-dir install --upgrade awscli==${AWSCLI_VERSION} && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*
 VOLUME /root/.aws


### PR DESCRIPTION
I noticed that disabling the pip and apk cache when installing packages make the images a few Megabytes smaller.